### PR TITLE
Automatically install packages when requested

### DIFF
--- a/R/configure.R
+++ b/R/configure.R
@@ -79,15 +79,15 @@ hermod_driver_load <- function(driver, call) {
                        i = "Valid choice{? is/s are}: {squote(valid)}"),
                      call = call)
     }
-    cache$drivers[[driver]] <- hermod_driver_create(driver)
+    cache$drivers[[driver]] <- hermod_driver_create(driver, call)
   }
   cache$drivers[[driver]]
 }
 
 
-hermod_driver_create <- function(name) {
+hermod_driver_create <- function(name, call = NULL) {
   pkg <- sprintf("hermod.%s", name)
-  ns <- ensure_package(pkg)
+  ns <- ensure_package(pkg, call)
   target <- sprintf("hermod_driver_%s", name)
 
   ## Users should never see these errors, we are in control of our own

--- a/R/provision.R
+++ b/R/provision.R
@@ -23,6 +23,7 @@ hermod_provision <- function(method = NULL, ..., driver = NULL,
   ## running on the headnode, either by job submission or directly,
   ## and we'll need to handle that too.
   root <- hermod_root(root)
+  ensure_package("conan2", rlang::current_env())
   env <- environment_load(environment, root, rlang::current_env())
   dat <- hermod_driver_prepare(driver, root, rlang::current_env())
   dat$driver$provision(method, dat$config, root$path$root, env, ...)

--- a/R/util.R
+++ b/R/util.R
@@ -20,17 +20,11 @@ ensure_package <- function(name, call = NULL) {
       "Please try installing '{name}' by running (in an empty session)",
       'install.packages("{name}", repos = c("https://mrc-ide.r-universe.dev",',
       '"https://cloud.r-project.org")')
-    if (getOption("hermod.no_install_missing", FALSE)) {
-        cli::cli_abort(
-          c("Package '{name}' is not available",
-            i = instructions,
-            i = paste("To automatically install missing packages, set",
-                      "options(hermod.no_install_missing = FALSE)")),
-          call = call)
-    } else {
+    if (getOption("hermod.auto_install_missing_packages", TRUE)) {
       cli::cli_alert_info("Trying to install '{name}'")
-      cli::cli_alert_info(
-        "To prevent this, set options(hermod.no_install_missing = TRUE)")
+      cli::cli_alert_info(paste(
+        "To prevent this, set",
+        "options(hermod.auto_install_missing_packages = FALSE)"))
       repos <- c("https://mrc-ide.r-universe.dev",
                  CRAN = "https://cloud.r-project.org")
       utils::install.packages(name, repos = repos)
@@ -41,6 +35,13 @@ ensure_package <- function(name, call = NULL) {
           call = call)
       }
       cli::cli_alert_success("Installation of '{name}' successful")
+    } else {
+      cli::cli_abort(
+        c("Package '{name}' is not available",
+          i = instructions,
+          i = paste("To automatically install missing packages, set",
+                    "options(hermod.auto_install_missing_packages = TRUE)")),
+        call = call)
     }
   }
   getNamespace(name)

--- a/R/util.R
+++ b/R/util.R
@@ -14,13 +14,34 @@ normalize_path <- function(path) {
 }
 
 
-ensure_package <- function(name) {
+ensure_package <- function(name, call = NULL) {
   if (!requireNamespace(name, quietly = TRUE)) {
-    ## TODO: once packages are on our universe, let's install
-    ## automatically too.
-    cli::cli_abort(c(
-      "Please install the '{name}' package",
-      c(i = "Try at https://github.com/mrc-ide/{name}")))
+    instructions <- paste(
+      "Please try installing '{name}' by running (in an empty session)",
+      'install.packages("{name}", repos = c("https://mrc-ide.r-universe.dev",',
+      '"https://cloud.r-project.org")')
+    if (getOption("hermod.no_install_missing", FALSE)) {
+        cli::cli_abort(
+          c("Package '{name}' is not available",
+            i = instructions,
+            i = paste("To automatically install missing packages, set",
+                      "options(hermod.no_install_missing = FALSE)")),
+          call = call)
+    } else {
+      cli::cli_alert_info("Trying to install '{name}'")
+      cli::cli_alert_info(
+        "To prevent this, set options(hermod.no_install_missing = TRUE)")
+      repos <- c("https://mrc-ide.r-universe.dev",
+                 CRAN = "https://cloud.r-project.org")
+      utils::install.packages(name, repos = repos)
+      if (!requireNamespace(name, quietly = TRUE)) {
+        cli::cli_abort(
+          c("Installation of '{name}' failed!",
+            i = instructions),
+          call = call)
+      }
+      cli::cli_alert_success("Installation of '{name}' successful")
+    }
   }
   getNamespace(name)
 }

--- a/R/windows.R
+++ b/R/windows.R
@@ -17,7 +17,8 @@
 ##'
 ##' @export
 windows_credentials <- function() {
-  ensure_package("hermod.windows")$dide_credentials()
+  ns <- ensure_package("hermod.windows", rlang::current_env())
+  ns$dide_credentials()
 }
 
 
@@ -50,6 +51,6 @@ windows_credentials <- function() {
 ##' @export
 ##' @author Rich FitzJohn
 windows_path <- function(name, path_local, path_remote, drive_remote) {
-  ensure_package("hermod.windows")$windows_path(name, path_local,
-                                                path_remote, drive_remote)
+  ns <- ensure_package("hermod.windows", rlang::current_env())
+  ns$windows_path(name, path_local,path_remote, drive_remote)
 }

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@
 To install `hermod`:
 
 ```r
-remotes::install_github("mrc-ide/hermod", upgrade = FALSE)
+install.packages(
+  "hermod",
+  repos = c("https://mrc-ide.r-universe.dev", "https://cloud.r-project.org"))
 ```
 
 ## License

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,0 +1,4 @@
+withr::local_options(
+  hermod.no_install_missing = TRUE,
+  .local_envir = teardown_env()
+)

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,4 +1,4 @@
 withr::local_options(
-  hermod.no_install_missing = TRUE,
+  hermod.auto_install_missing_packages = FALSE,
   .local_envir = teardown_env()
 )

--- a/tests/testthat/test-configure.R
+++ b/tests/testthat/test-configure.R
@@ -80,7 +80,7 @@ test_that("can load a driver", {
   expect_identical(result, elsewhere_driver())
 
   mockery::expect_called(mock_create, 1)
-  expect_equal(mockery::mock_args(mock_create)[[1]], list("windows"))
+  expect_equal(mockery::mock_args(mock_create)[[1]], list("windows", NULL))
   expect_identical(cache$drivers$windows, result)
 
   expect_identical(hermod_driver_load("windows", NULL), result)
@@ -109,7 +109,7 @@ test_that("creating a package loads function and calls target function", {
 
   mockery::expect_called(mock_ensure_package, 1)
   expect_equal(mockery::mock_args(mock_ensure_package)[[1]],
-               list("hermod.foo"))
+               list("hermod.foo", NULL))
   mockery::expect_called(mock_ns$hermod_driver_foo, 1)
   expect_equal(mockery::mock_args(mock_ns$hermod_driver_foo)[[1]],
                list())

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -13,9 +13,76 @@ test_that("can ensure we have a package", {
 
 
 test_that("can fail if namespace not available", {
+  withr::local_options(hermod.no_install_missing = TRUE)
   err <- expect_error(
     ensure_package("hermod.area51"),
-    "Please install the 'hermod.area51' package")
-  expect_equal(err$body,
-               c(i = "Try at https://github.com/mrc-ide/hermod.area51"))
+    "Package 'hermod.area51' is not available")
+  expect_length(err$body, 2)
+  expect_match(
+    err$body[[1]],
+    "Please try installing 'hermod.area51' by running")
+  expect_match(
+    err$body[[2]],
+    "To automatically install missing packages, set options")
+})
+
+
+test_that("can install missing packages if wanted", {
+  withr::local_options(hermod.no_install_missing = NULL)
+
+  mock_require_namespace <- mockery::mock(FALSE, TRUE)
+  mock_install_packages <- mockery::mock()
+  mock_get_namespace <- mockery::mock()
+  mockery::stub(ensure_package, "requireNamespace", mock_require_namespace)
+  mockery::stub(ensure_package, "utils::install.packages", mock_install_packages)
+  mockery::stub(ensure_package, "getNamespace", mock_get_namespace)
+
+  msg <- capture_messages(ensure_package("hermod.area51"))
+  expect_match(msg, "Trying to install 'hermod.area51'", all = FALSE)
+  expect_match(msg, "To prevent this, set options", all = FALSE)
+  expect_match(msg, "Installation of 'hermod.area51' successful", all = FALSE)
+
+  mockery::expect_called(mock_require_namespace, 2)
+  expect_equal(mockery::mock_args(mock_require_namespace),
+               rep(list(list("hermod.area51", quietly = TRUE)), 2))
+
+  mockery::expect_called(mock_install_packages, 1)
+  expect_equal(
+    mockery::mock_args(mock_install_packages)[[1]],
+    list("hermod.area51", repos = c("https://mrc-ide.r-universe.dev",
+                                    CRAN = "https://cloud.r-project.org")))
+
+  mockery::expect_called(mock_get_namespace, 1)
+  expect_equal(mockery::mock_args(mock_get_namespace),
+               list(list("hermod.area51")))
+})
+
+
+test_that("can error if missing package installation fails", {
+  withr::local_options(hermod.no_install_missing = NULL)
+
+  mock_require_namespace <- mockery::mock(FALSE, FALSE)
+  mock_install_packages <- mockery::mock()
+  mock_get_namespace <- mockery::mock()
+  mockery::stub(ensure_package, "requireNamespace", mock_require_namespace)
+  mockery::stub(ensure_package, "utils::install.packages", mock_install_packages)
+  mockery::stub(ensure_package, "getNamespace", mock_get_namespace)
+
+  err <- expect_error(
+    suppressMessages(ensure_package("hermod.area51")),
+    "Installation of 'hermod.area51' failed!")
+  expect_length(err$body, 1)
+  expect_match(err$body, "Please try installing 'hermod.area51' by running")
+
+  mockery::expect_called(mock_require_namespace, 2)
+  expect_equal(mockery::mock_args(mock_require_namespace),
+               rep(list(list("hermod.area51", quietly = TRUE)), 2))
+
+  mockery::expect_called(mock_install_packages, 1)
+  expect_equal(
+    mockery::mock_args(mock_install_packages)[[1]],
+    list("hermod.area51", repos = c("https://mrc-ide.r-universe.dev",
+                                    CRAN = "https://cloud.r-project.org")))
+
+  mockery::expect_called(mock_get_namespace, 0)
 })

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -13,7 +13,7 @@ test_that("can ensure we have a package", {
 
 
 test_that("can fail if namespace not available", {
-  withr::local_options(hermod.no_install_missing = TRUE)
+  withr::local_options(hermod.auto_install_missing_packages = FALSE)
   err <- expect_error(
     ensure_package("hermod.area51"),
     "Package 'hermod.area51' is not available")
@@ -28,13 +28,14 @@ test_that("can fail if namespace not available", {
 
 
 test_that("can install missing packages if wanted", {
-  withr::local_options(hermod.no_install_missing = NULL)
+  withr::local_options(hermod.auto_install_missing_packages = NULL)
 
   mock_require_namespace <- mockery::mock(FALSE, TRUE)
   mock_install_packages <- mockery::mock()
   mock_get_namespace <- mockery::mock()
   mockery::stub(ensure_package, "requireNamespace", mock_require_namespace)
-  mockery::stub(ensure_package, "utils::install.packages", mock_install_packages)
+  mockery::stub(ensure_package, "utils::install.packages",
+                mock_install_packages)
   mockery::stub(ensure_package, "getNamespace", mock_get_namespace)
 
   msg <- capture_messages(ensure_package("hermod.area51"))
@@ -59,13 +60,14 @@ test_that("can install missing packages if wanted", {
 
 
 test_that("can error if missing package installation fails", {
-  withr::local_options(hermod.no_install_missing = NULL)
+  withr::local_options(hermod.auto_install_missing_packages = NULL)
 
   mock_require_namespace <- mockery::mock(FALSE, FALSE)
   mock_install_packages <- mockery::mock()
   mock_get_namespace <- mockery::mock()
   mockery::stub(ensure_package, "requireNamespace", mock_require_namespace)
-  mockery::stub(ensure_package, "utils::install.packages", mock_install_packages)
+  mockery::stub(ensure_package, "utils::install.packages",
+                mock_install_packages)
   mockery::stub(ensure_package, "getNamespace", mock_get_namespace)
 
   err <- expect_error(

--- a/tests/testthat/test-windows.R
+++ b/tests/testthat/test-windows.R
@@ -6,8 +6,9 @@ test_that("windows_path calls hermod.windows", {
   windows_path("home", p, "//fi--san03/homes/bob", "Q:")
 
   mockery::expect_called(mock_ensure_package, 1)
-  expect_equal(mockery::mock_args(mock_ensure_package)[[1]],
-               list("hermod.windows"))
+  args <- mockery::mock_args(mock_ensure_package)[[1]]
+  expect_equal(args[[1]], "hermod.windows")
+  expect_type(args[[2]], "environment")
 
   mockery::expect_called(mock_pkg$windows_path, 1)
   expect_equal(mockery::mock_args(mock_pkg$windows_path)[[1]],
@@ -22,8 +23,9 @@ test_that("windows credentials passes through to dide_credentials", {
   windows_credentials()
 
   mockery::expect_called(mock_ensure_package, 1)
-  expect_equal(mockery::mock_args(mock_ensure_package)[[1]],
-               list("hermod.windows"))
+  args <- mockery::mock_args(mock_ensure_package)[[1]]
+  expect_equal(args[[1]], "hermod.windows")
+  expect_type(args[[2]], "environment")
 
   mockery::expect_called(mock_pkg$dide_credentials, 1)
   expect_equal(mockery::mock_args(mock_pkg$dide_credentials)[[1]],


### PR DESCRIPTION
Small PR which means that users can just install `hermod` and we'll grab the rest as we need them.

We need to (later, I think) work out how to flag when version numbers are incompatible, that might take some care.

If you want to see this in action:

```r
remove.packages(c("hermod", "hermod.windows", "conan2"))
```

then from somewhere on the network share:

```
> hermod::hermod_init(".")
✔ Initialised hermod at '.'
ℹ Next, call 'hermod_configure()'
> hermod::hermod_configure("windows")
ℹ Trying to install 'hermod.windows'
ℹ To prevent this, set options(hermod.no_install_missing = TRUE)
Installing package into ‘/home/rfitzjoh/lib/R/library’
(as ‘lib’ is unspecified)
also installing the dependency ‘conan2’

trying URL 'https://mrc-ide.r-universe.dev/src/contrib/conan2_1.9.90.tar.gz'
Content type 'application/x-gzip' length 1139673 bytes (1.1 MB)
==================================================
downloaded 1.1 MB

trying URL 'https://mrc-ide.r-universe.dev/src/contrib/hermod.windows_0.1.0.tar.gz'
Content type 'application/x-gzip' length 110784 bytes (108 KB)
==================================================
downloaded 108 KB

* installing *source* package ‘conan2’ ...
** using staged installation
** R
** inst
** byte-compile and prepare package for lazy loading
** help
*** installing help indices
*** copying figures
** building package indices
** testing if installed package can be loaded from temporary location
** testing if installed package can be loaded from final location
** testing if installed package keeps a record of temporary installation path
* DONE (conan2)
* installing *source* package ‘hermod.windows’ ...
** using staged installation
** R
** inst
** byte-compile and prepare package for lazy loading
** help
*** installing help indices
** building package indices
** testing if installed package can be loaded from temporary location
** testing if installed package can be loaded from final location
** testing if installed package keeps a record of temporary installation path
* DONE (hermod.windows)

The downloaded source packages are in
	‘/tmp/RtmpJAdNQJ/downloaded_packages’
✔ Installation of 'hermod.windows' successful
```