### PR TITLE
Allow configuration at initialisation

### DIFF
--- a/R/configure.R
+++ b/R/configure.R
@@ -24,8 +24,18 @@ hermod_configure <- function(driver, ..., root = NULL) {
     root$config <- list()
   }
 
-  saveRDS(config, file.path(root$path$config, paste0(driver, ".rds")))
+  path_config <- file.path(root$path$config, paste0(driver, ".rds"))
+  is_new <- !file.exists(path_config)
+  is_changed <- saverds_if_different(config, path_config)
   root$config[[driver]] <- config
+
+  if (is_new) {
+    cli::cli_alert_success("Configured hermod to use '{driver}'")
+  } else if (is_changed) {
+    cli::cli_alert_success("Updated configuration for '{driver}'")
+  } else {
+    cli::cli_alert_info("Configuration for '{driver}' unchanged")
+  }
 
   invisible()
 }

--- a/R/root.R
+++ b/R/root.R
@@ -7,24 +7,42 @@
 ##'
 ##' @title Create a hermod root
 ##'
-##' @param path The path to the root, defaulting the current
+##' @param root The path to the root, defaulting the current
 ##'   directory.
+##'
+##' @param driver Optionally, the name of a driver to configure
+##'
+##' @param ... Arguments passed through to [hermod_configure] if
+##'   `driver` is non-NULL.
 ##'
 ##' @return Invisibly, the root object
 ##'
 ##' @export
-hermod_init <- function(path = ".") {
-  dest <- file.path(path, "hermod.json")
+hermod_init <- function(root = ".", driver = NULL, ...) {
+  dest <- file.path(root, "hermod.json")
   if (file.exists(dest)) {
-    cli::cli_alert_info("hermod already initialised at '{path}'")
+    cli::cli_alert_info("hermod already initialised at '{root}'")
   } else {
-    dir.create(path, FALSE, TRUE)
+    dir.create(root, FALSE, TRUE)
     writeLines("{}", dest)
-    cli::cli_alert_success("Initialised hermod at '{path}'")
+    cli::cli_alert_success("Initialised hermod at '{root}'")
   }
-  root <- hermod_root(path)
-  if (is.null(root$config)) {
-    cli::cli_alert_info("Next, call 'hermod_configure()'")
+  root <- hermod_root(root)
+  if (is.null(driver)) {
+    if (is.null(root$config)) {
+      cli::cli_alert_info("Next, call 'hermod_configure()'")
+    }
+  } else {
+    tryCatch(
+      hermod_configure(driver, ..., root = root),
+      error = function(e) {
+        cli::cli_abort(
+          c("Configuration failed",
+            i = paste("Your root is still initialised, and if previously",
+                      " configured the configuration is unchanged"),
+            i = "Try again with 'hermod::hermod_configure()' directly"),
+          parent = e)
+      })
   }
   invisible(root)
 }

--- a/R/util.R
+++ b/R/util.R
@@ -61,3 +61,12 @@ vcapply <- function(...) {
 na_omit <- function(x) {
   x[!is.na(x)]
 }
+
+
+saverds_if_different <- function(object, path) {
+  skip <- file.exists(path) && identical(readRDS(path), object)
+  if (!skip) {
+    saveRDS(object, path)
+  }
+  !skip
+}

--- a/drivers/windows/tests/testthat/helper-config.R
+++ b/drivers/windows/tests/testthat/helper-config.R
@@ -4,7 +4,8 @@ example_root <- function(mount_path, sub = "b/c") {
   root <- suppressMessages(hermod::hermod_init(path))
   path <- normalize_path(path)
   shares <- windows_path("home", mount_path, "//host/share/path", "X:")
-  config <- hermod::hermod_configure("windows", shares = shares, root = root)
+  suppressMessages(
+    config <- hermod::hermod_configure("windows", shares = shares, root = root))
   root
 }
 

--- a/drivers/windows/tests/testthat/test-config.R
+++ b/drivers/windows/tests/testthat/test-config.R
@@ -36,9 +36,10 @@ test_that("can configure a root", {
   shares <- windows_path("home", mount, "//host/share/path", "X:")
   cmp <- withr::with_dir(path, windows_configure(shares, "4.3.0"))
 
-  hermod::hermod_configure(driver = "windows",
-                           shares = shares,
-                           r_version = "4.3.0",
-                           root = root)
+  suppressMessages(
+    hermod::hermod_configure(driver = "windows",
+                             shares = shares,
+                             r_version = "4.3.0",
+                             root = root))
   expect_equal(root$config$windows, cmp)
 })

--- a/man/hermod_init.Rd
+++ b/man/hermod_init.Rd
@@ -4,11 +4,16 @@
 \alias{hermod_init}
 \title{Create a hermod root}
 \usage{
-hermod_init(path = ".")
+hermod_init(root = ".", driver = NULL, ...)
 }
 \arguments{
-\item{path}{The path to the root, defaulting the current
+\item{root}{The path to the root, defaulting the current
 directory.}
+
+\item{driver}{Optionally, the name of a driver to configure}
+
+\item{...}{Arguments passed through to \link{hermod_configure} if
+\code{driver} is non-NULL.}
 }
 \value{
 Invisibly, the root object

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -6,7 +6,8 @@ test_that("can submit a task via a driver", {
   init_quietly(path_here)
   init_quietly(path_there)
 
-  hermod_configure("elsewhere", path = path_there, root = path_here)
+  suppressMessages(
+    hermod_configure("elsewhere", path = path_there, root = path_here))
 
   id <- withr::with_dir(path_here, task_create_explicit(quote(getwd())))
   expect_equal(task_status(id, root = path_here), "created")
@@ -40,7 +41,8 @@ test_that("forbid additional arguments to submission, for now", {
   path_there <- withr::local_tempdir()
   init_quietly(path_here)
   init_quietly(path_there)
-  hermod_configure("elsewhere", path = path_there, root = path_here)
+  suppressMessages(
+    hermod_configure("elsewhere", path = path_there, root = path_here))
   id <- withr::with_dir(path_here, task_create_explicit(quote(getwd())))
   expect_error(
     withr::with_dir(path_here, task_submit(id, cores = 2)),
@@ -57,7 +59,8 @@ test_that("fetch driver used for submission", {
   init_quietly(path_there)
   root <- hermod_root(path_here)
 
-  hermod_configure("elsewhere", path = path_there, root = path_here)
+  suppressMessages(
+    hermod_configure("elsewhere", path = path_there, root = path_here))
 
   id <- withr::with_dir(path_here, task_create_explicit(quote(getwd())))
 
@@ -78,7 +81,8 @@ test_that("knowning driver stops refetching from disk", {
   init_quietly(path_here)
   init_quietly(path_there)
   root <- hermod_root(path_here)
-  hermod_configure("elsewhere", path = path_there, root = path_here)
+  suppressMessages(
+    hermod_configure("elsewhere", path = path_there, root = path_here))
   id <- withr::with_dir(path_here, task_create_explicit(quote(getwd())))
   withr::with_dir(path_here, task_submit(id))
 
@@ -97,7 +101,8 @@ test_that("can retrieve a task result via a driver", {
   init_quietly(path_here)
   init_quietly(path_there)
   root <- hermod_root(path_here)
-  hermod_configure("elsewhere", path = path_there, root = path_here)
+  suppressMessages(
+    hermod_configure("elsewhere", path = path_there, root = path_here))
   id <- withr::with_dir(path_here, task_create_explicit(quote(getwd())))
   withr::with_dir(path_here, task_submit(id))
   expect_error(
@@ -121,7 +126,8 @@ test_that("can call provision", {
   init_quietly(path_here)
   init_quietly(path_there)
   root <- hermod_root(path_here)
-  hermod_configure("elsewhere", path = path_there, root = path_here)
+  suppressMessages(
+    hermod_configure("elsewhere", path = path_there, root = path_here))
   writeLines('install.packages("R6")', file.path(path_here, "provision.R"))
 
   path_root <- root$path$root
@@ -136,7 +142,6 @@ test_that("can call provision", {
 })
 
 
-
 test_that("can cancel tasks", {
   elsewhere_register()
   path_here <- withr::local_tempdir()
@@ -144,7 +149,8 @@ test_that("can cancel tasks", {
   init_quietly(path_here)
   init_quietly(path_there)
   root <- hermod_root(path_here)
-  hermod_configure("elsewhere", path = path_there, root = path_here)
+  suppressMessages(
+    hermod_configure("elsewhere", path = path_there, root = path_here))
   id <- withr::with_dir(
     path_here,
     task_create_explicit(quote(sqrt(2))))

--- a/tests/testthat/test-root.R
+++ b/tests/testthat/test-root.R
@@ -36,3 +36,36 @@ test_that("Error if root not found", {
   path <- withr::local_tempdir()
   expect_error(hermod_root(path))
 })
+
+
+test_that("can create a root and configure in one step", {
+  elsewhere_register()
+  path <- withr::local_tempdir()
+  path_here <- file.path(path, "here")
+  path_there <- file.path(path, "there")
+  suppressMessages(hermod_init(path_there))
+
+  # hermod_init(path_here)
+  msg <- capture_messages(
+    hermod_init(path_here, "elsewhere", path = path_there))
+  expect_length(msg, 2)
+  expect_match(msg[[1]], "Initialised hermod")
+  expect_match(msg[[2]], "Configured hermod to use 'elsewhere'")
+
+  expect_equal(names(hermod_root(path_here)$config), "elsewhere")
+})
+
+
+test_that("Failure to configure a root does not destroy it", {
+  elsewhere_register()
+  path <- withr::local_tempdir()
+  path_here <- file.path(path, "here")
+  path_there <- file.path(path, "there")
+
+  # hermod_init(path_here)
+  err <- expect_error(
+    suppressMessages(hermod_init(path_here, "elsewhere", path = path_there)),
+    "Configuration failed")
+  expect_true(file.exists(file.path(path_here, "hermod.json")))
+  expect_null(hermod_root(path_here)$config)
+})

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -88,3 +88,23 @@ test_that("can error if missing package installation fails", {
 
   mockery::expect_called(mock_get_namespace, 0)
 })
+
+
+test_that("saverds_if_different updates files when different", {
+  path <- withr::local_tempfile()
+  expect_true(saverds_if_different(list(1, "two"), path))
+  expect_equal(readRDS(path), list(1, "two"))
+
+  expect_true(saverds_if_different(list(1, "two", 3L), path))
+  expect_equal(readRDS(path), list(1, "two", 3L))
+})
+
+
+test_that("saverds_if_different does not update file when not different", {
+  path <- withr::local_tempfile()
+  saveRDS(list(1, "two"), path)
+  mock_saverds <- mockery::mock()
+  mockery::stub(saverds_if_different, "saveRDS", mock_saverds)
+  expect_false(saverds_if_different(list(1, "two"), path))
+  mockery::expect_called(mock_saverds, 0)
+})

--- a/tests/testthat/test-zzz-integration.R
+++ b/tests/testthat/test-zzz-integration.R
@@ -5,7 +5,8 @@ test_that("can provision a library", {
   init_quietly(path_here)
   init_quietly(path_there)
   root <- hermod_root(path_here)
-  hermod_configure("elsewhere", path = path_there, root = path_here)
+  suppressMessages(
+    hermod_configure("elsewhere", path = path_there, root = path_here))
   writeLines('install.packages("R6")', file.path(path_here, "provision.R"))
   hermod_provision(root = path_here, show_log = FALSE)
   expect_true(file.exists(file.path(path_there, "hermod", "lib", "R6")))


### PR DESCRIPTION
Allows passing `driver = "windows"` to `hermod_init()` which reduces boilerplate on initialisation. Also made `hermod_configure` more chatty